### PR TITLE
Fix safari bug

### DIFF
--- a/src/components/WorkingGroupCard/WorkingGroupCard.module.scss
+++ b/src/components/WorkingGroupCard/WorkingGroupCard.module.scss
@@ -40,7 +40,7 @@
   &::after {
     content: '';
     z-index: $z-level-1;
-    background: linear-gradient(to right, transparent 40%, $white 75%);
+    background: linear-gradient(to right, rgba($white, 0) 40%, $white 75%);
     position: absolute;
     left: 0;
     right: 0;


### PR DESCRIPTION
Safari interprets 'transparent' as rgba(0,0,0,0) instead of rgba(255,255,255,0) creating an ugly gradient.